### PR TITLE
Removed Hyelip's website & updated student status

### DIFF
--- a/_data/people.csv
+++ b/_data/people.csv
@@ -8,9 +8,9 @@ Neung,Ryu,Master student,current,,,,,,ababc100564@gmail.com
 Hye-Young,Jo,Master student,current,https://hyeyoungjo.github.io,,hye-young-jo-2743b189,,,hyeyoungjo@kaist.ac.kr
 Eunhee,Jung,Master student,current,,,,,,eunhee4526@kaist.ac.kr
 Wooje,Chang,Master student,current,https://www.woojechang.com/,,https://www.linkedin.com/in/wooje-chang-3a4772b8,,,changwooje@gmail.com
-Hyunseung,Lim,Undergrad intern,current,,,,people/임현승/100006569493290,,charlie9807@kaist.ac.kri
+Hyunseung,Lim,Undergrad intern,current,,,,people/?????????/100006569493290,,charlie9807@kaist.ac.kri
 Yoosang,Yoon,Undergrad intern,current,,,,,,soulmilk98@kaist.ac.kr
-Leila Hyelip,Lee,Ph.D. student,alumni,http://www.hyelip.com/,,,,,hyelip.lee@kaist.ac.kr
+Leila Hyelip,Lee,Ph.D. student,alumni,,,,,,hyelip.lee@kaist.ac.kr
 Yoonji,Kim,Ph.D. 2020,alumni,http://www.yoonji-kim.com,/yoonji-kim,yoonji-kim,,,yoonji@kaist.ac.kr
 Daye,Kang,Master 2021,alumni,https://www.dayekang.info,,,,,dayekang@kaist.ac.kr
 Hyein,Lee,Master 2020,alumni,http://hyein.me,,,,,hyein.l@kaist.ac.kr

--- a/_data/people.csv
+++ b/_data/people.csv
@@ -1,15 +1,15 @@
 name,lastname,position,status,homepage,github,linkedin,facebook,scholar,email
 Andrea,Bianchi,Associate Professor,current,/andrea,makinteract,andrea-bianchi-87656b6,,wVDtZB0AAAAJ&hl,andrea@kaist.ac.kr
-Seungwoo,Je,Ph.D. student,current,http://www.seungwooje.com,,seungwooje,,yecBkvAAAAAJ&hl,jeboungho@gmail.com
+Seungwoo,Je,Ph.D. student,alumni,http://www.seungwooje.com,,seungwooje,,yecBkvAAAAAJ&hl,jeboungho@gmail.com
 Kongpyung,Moon,Ph.D. student,current,https://www.kpmoon.com,Mjkp,jkpmoon,,,jkpmoon@kaist.ac.kr
 Myung Jin,Kim,Ph.D. student,current,,,myung-jin-kim-044b63135,3dkmj,ypCkHjEAAAAJ&hl,davidkim9404@kaist.ac.kr
-Joongi,Shin,Ph.D. student,current,https://www.joongishin.com,,joongi-shin,,l5RYWKAAAAAJ,joongishin@gmail.com
-Neung,Ryu,Master student,current,,,,,,ababc100564@gmail.com
+Joongi,Shin,Ph.D. student,alumni,https://www.joongishin.com,,joongi-shin,,l5RYWKAAAAAJ,joongishin@gmail.com
+Neung,Ryu,Master student,alumni,,,,,,ababc100564@gmail.com
 Hye-Young,Jo,Master student,current,https://hyeyoungjo.github.io,,hye-young-jo-2743b189,,,hyeyoungjo@kaist.ac.kr
-Eunhee,Jung,Master student,current,,,,,,eunhee4526@kaist.ac.kr
+Eunhee,Jung,Master student,alumni,,,,,,eunhee4526@kaist.ac.kr
 Wooje,Chang,Master student,current,https://www.woojechang.com/,,https://www.linkedin.com/in/wooje-chang-3a4772b8,,,changwooje@gmail.com
-Hyunseung,Lim,Undergrad intern,current,,,,people/?????????/100006569493290,,charlie9807@kaist.ac.kri
-Yoosang,Yoon,Undergrad intern,current,,,,,,soulmilk98@kaist.ac.kr
+Hyunseung,Lim,Undergrad intern,alumni,,,,people/ÀÓÇö½Â/100006569493290,,charlie9807@kaist.ac.kri
+Yoosang,Yoon,Undergrad intern,alumni,,,,,,soulmilk98@kaist.ac.kr
 Leila Hyelip,Lee,Ph.D. student,alumni,,,,,,hyelip.lee@kaist.ac.kr
 Yoonji,Kim,Ph.D. 2020,alumni,http://www.yoonji-kim.com,/yoonji-kim,yoonji-kim,,,yoonji@kaist.ac.kr
 Daye,Kang,Master 2021,alumni,https://www.dayekang.info,,,,,dayekang@kaist.ac.kr


### PR DESCRIPTION
1. Hyelip's website link removed by request (domain no longer active)
2. Updated student status (current/alumni)